### PR TITLE
fix: filemanager readZipEntry filename was not sent

### DIFF
--- a/packages/aice-nfm/src/FileManager.js
+++ b/packages/aice-nfm/src/FileManager.js
@@ -11,8 +11,8 @@ import unzipper from 'unzipper';
 const fsp = fs.promises;
 
 export default class FileManager {
-  constructor(cli) {
-    this.cli = cli;
+  constructor(settings) {
+    this.settings = settings || {};
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -70,7 +70,7 @@ export default class FileManager {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  async readZipEntry(entry, filename, outputDir) {
+  async readZipEntry(entry, filename, outputDir = this.settings.outputDir) {
     const content = await entry.buffer();
     if (filename) {
       const f = path.join(outputDir, filename);

--- a/packages/aice-utils/src/index.js
+++ b/packages/aice-utils/src/index.js
@@ -84,7 +84,7 @@ class AIceUtils {
   async handleZipEntry(filename, outputDir, entry, fileManager) {
     const result = { autoDrain: true };
     if (filename.endsWith('.json')) {
-      const raw = await fileManager.readZipEntry(entry, outputDir);
+      const raw = await fileManager.readZipEntry(entry, filename, outputDir);
       result.autoDrain = false;
       try {
         result.content = JSON.parse(raw);


### PR DESCRIPTION

Checklist:
- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

Review targets:
- nodejs / npm / yarn
